### PR TITLE
feat(MESDP-5484): set default type='button' to Button

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -43,6 +43,7 @@ export const Button = forwardRef<HTMLButtonElement, IButtonProps>(
       iconButton,
       className,
       style,
+      type = 'button',
       ...props
     },
     ref
@@ -81,14 +82,14 @@ export const Button = forwardRef<HTMLButtonElement, IButtonProps>(
 
     if (iconButton) {
       return (
-        <button ref={ref} className={classes} style={style} {...props} data-ui-icon-button>
+        <button ref={ref} className={classes} style={style} type={type} {...props} data-ui-icon-button>
           {iconButton}
         </button>
       );
     }
 
     return (
-      <button ref={ref} className={classes} style={style} {...props} data-ui-button>
+      <button ref={ref} className={classes} style={style} type={type} {...props} data-ui-button>
         {startBadge != null && (
           <span className={getIconClass(EButtonNodesPosition.left)} data-ui-button-badge-left>
             <ButtonBadge badge={startBadge} size={size} />

--- a/src/components/_storybook/Stories/components/Tests.tsx
+++ b/src/components/_storybook/Stories/components/Tests.tsx
@@ -1,5 +1,6 @@
-import React, { FC } from 'react';
-
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+// import React, { FC } from 'react';
 import { Chip, Typography } from '@components/index';
 // Add TS disable error comment for import file from under the root direction
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -17,7 +18,9 @@ const Tests: FC<{ componentName: string }> = ({ componentName }) => {
       {currentComponentTest?.assertionResults.map(({ title, status }) => (
         <div className={styles.test} key={title}>
           <div className={styles[status]}></div>
-          <Typography variant="Body1-Bold" className={styles.text}>{title}</Typography>
+          <Typography variant="Body1-Bold" className={styles.text}>
+            {title}
+          </Typography>
           <div className={styles.chip}>
             <Chip color="success" variant="solid">
               {status}


### PR DESCRIPTION
[По умолчанию во всех браузерах, кроме IE у button type='submit'](https://www.w3schools.com/jsref/prop_pushbutton_type.asp). 
Это может примести к неожиданным сценариям при использовании внутри ```<form />```
Например в компоненте ```<DatePIcker />``` есть кнопки для переключения месяцев (вперед/назад), они сейчас также триггерят submit событие формы.

Предлагаю по умолчанию для компонента ```<Button />``` установить type='button'. Чтобы в дальнейшем не исправлять это в других компонентах, где вложено используется Button.