### PR TITLE
feat(treelist_feat_drag_props): Drag start end props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nlmk/ds-2.0",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "author": "NLMK IT",
   "public": false,
   "main": "lib/index.js",

--- a/src/components/Table/Top/types.ts
+++ b/src/components/Table/Top/types.ts
@@ -12,7 +12,7 @@ export interface ITopProps extends Omit<ThHTMLAttributes<HTMLTableHeaderCellElem
   /** Размер ячейки заголовка */
   size?: `${ESize}`;
   /** Текстовое содержимое заголовка */
-  title?: string;
+  title?: ReactNode;
   /** Флаг отключения ячейки */
   disable?: boolean;
   /** Флаг включения сортировки */

--- a/src/components/TreeList/README.md
+++ b/src/components/TreeList/README.md
@@ -9,7 +9,7 @@
 ```jsx
 import { TreeList } from '@nlmk/ds-2.0';
 
-<TreeList data={treeData} checkable draggable onSelectedNode={onSelectedNode} onDataAfterDrag={onDataAfterDrag} />;
+<TreeList data={treeData} checkable draggable onSelectedNode={onSelectedNode} onDataAfterDrag={onDataAfterDrag} onDragStart={onDragStart} onDragEnd={onDragEnd} />;
 ```
 
 ## Props
@@ -19,6 +19,8 @@ import { TreeList } from '@nlmk/ds-2.0';
 | data                | TNodeItem[]                     | -            | Данные для дерева в виде массива узлов                                             |
 | onSelectedNode      | (e: TSelectedNodeEvent) => void | -            | Обработчик события выбора узла                                                     |
 | onDataAfterDrag     | (e: TNodeItem[]) => void        | -            | Обработчик события после перетаскивания                                            |
+| onDragStart         | (e: TDragEvent[]) => void       | -            | Обработчик события начала перетаскивания |
+| onDragEnd           | (e: TDragEvent[]) => void       | -            | Обработчик события конца перетаскивания |
 | checkable           | boolean                         | false        | Флаг отображения чекбоксов                                                         |
 | draggable           | boolean                         | false        | Флаг возможности перетаскивания узлов                                              |
 | checkableSimple     | boolean                         | false        | Флаг упрощённого выбора чекбоксов                                                  |
@@ -60,7 +62,7 @@ type TNodeItem = {
 type TSelectedNodeEvent = {
   currentKey?: Key; // Ключ текущего узла
   allSelectedKeys?: Key[]; // Все выбранные ключи
-  isCheked?: boolean; // Статус выбора
+  isCheсked?: boolean; // Статус выбора
 };
 ```
 
@@ -73,6 +75,13 @@ type TDropEvent = {
   dropPosition: number; // Позиция вставки
   dropToGap: boolean; // Вставка между узлами
 };
+```
+
+```typescript
+type TDragEvent = {
+  event: React.DragEvent<T>; // Событие перетаскивания
+  node: EventDataNode<DataNode>; // Перетаскиваемый узел
+}
 ```
 
 ## Стилизация

--- a/src/components/TreeList/README.md
+++ b/src/components/TreeList/README.md
@@ -19,8 +19,8 @@ import { TreeList } from '@nlmk/ds-2.0';
 | data                | TNodeItem[]                     | -            | Данные для дерева в виде массива узлов                                             |
 | onSelectedNode      | (e: TSelectedNodeEvent) => void | -            | Обработчик события выбора узла                                                     |
 | onDataAfterDrag     | (e: TNodeItem[]) => void        | -            | Обработчик события после перетаскивания                                            |
-| onDragStart         | (e: TDragEvent[]) => void       | -            | Обработчик события начала перетаскивания |
-| onDragEnd           | (e: TDragEvent[]) => void       | -            | Обработчик события конца перетаскивания |
+| onDragStart         | (e: TDragEvent) => void         | -            | Обработчик события начала перетаскивания |
+| onDragEnd           | (e: TDragEvent) => void         | -            | Обработчик события конца перетаскивания |
 | checkable           | boolean                         | false        | Флаг отображения чекбоксов                                                         |
 | draggable           | boolean                         | false        | Флаг возможности перетаскивания узлов                                              |
 | checkableSimple     | boolean                         | false        | Флаг упрощённого выбора чекбоксов                                                  |

--- a/src/components/TreeList/TreeList.test.tsx
+++ b/src/components/TreeList/TreeList.test.tsx
@@ -87,4 +87,24 @@ describe('src/components/TreeList', () => {
     const { getByTestId } = render(<TreeList data={dataWithControls} />);
     expect(getByTestId('controls')).toBeInTheDocument();
   });
+
+  // Тест обработчиков onDragStart и onDragEnd
+  test('It should handle drag start and end callbacks', () => {
+    const onDragStart = jest.fn();
+    const onDragEnd = jest.fn();
+    const { container } = render(<TreeList data={MOCK_TREE_DATA} draggable onDragStart={onDragStart} onDragEnd={onDragEnd} />);
+
+    const dragNode = container.querySelector('[data-key="0-0-0"]');
+    const dropNode = container.querySelector('[data-key="0-1"]');
+
+    if (dragNode && dropNode) {
+      fireEvent.dragStart(dragNode);
+      expect(onDragStart).toHaveBeenCalled();
+
+      fireEvent.dragEnter(dropNode);
+      fireEvent.dragOver(dropNode);
+      fireEvent.drop(dropNode);
+      expect(onDragEnd).toHaveBeenCalled();
+    }
+  });
 });

--- a/src/components/TreeList/_stories/Stories.tsx
+++ b/src/components/TreeList/_stories/Stories.tsx
@@ -68,6 +68,14 @@ export default App = () => {
     console.log('Структура после перемещения:', newData);
   };
 
+  const onDragStart = (e) => {
+    console.log('Событие начала перетаскивания: ',  e.event)
+  }
+  
+  const onDragEnd = (e) => {
+    console.log('Событие конца перетаскивания: ', e.event)
+  }
+
   return (
     <TreeList
       data={defaultTreeData}
@@ -76,6 +84,8 @@ export default App = () => {
       rowHeight="s"
       onSelectedNode={onSelectedNode}
       onDataAfterDrag={onDataAfterDrag}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
     />
   );
 };`;

--- a/src/components/TreeList/_stories/TreeList.stories.tsx
+++ b/src/components/TreeList/_stories/TreeList.stories.tsx
@@ -5,7 +5,7 @@ import { Box } from '@components/index';
 import styles from './TreeList.module.scss';
 
 import TreeList from '../TreeList';
-import { TNodeItem, TSelectedNodeEvent, TTreeListProps } from '../types';
+import { TDragEvent, TNodeItem, TSelectedNodeEvent, TTreeListProps } from '../types';
 import { DEFAULT_TREE_DATA } from './constants';
 
 const withWrapper = (Story: any) => <div className={styles.wrapper}>{<Story />}</div>;
@@ -29,6 +29,14 @@ export const TreeListDefault = (argTypes: TTreeListProps): JSX.Element => {
     setData(newData);
   };
 
+  const onDragStart = (e: TDragEvent) => {
+      console.log('Drag start event: ',  e.event)
+    }
+  
+    const onDragEnd = (e: TDragEvent) => {
+      console.log('Drag end event; ', e.event)
+    }
+
   return (
     <TreeList
       data={data}
@@ -37,6 +45,8 @@ export const TreeListDefault = (argTypes: TTreeListProps): JSX.Element => {
       rowHeight={argTypes.rowHeight}
       onSelectedNode={onSelectedNode}
       onDataAfterDrag={onDataAfterDrag}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
     />
   );
 };

--- a/src/components/TreeList/_stories/argsTypes.ts
+++ b/src/components/TreeList/_stories/argsTypes.ts
@@ -25,6 +25,24 @@ const argsTypes = {
       }
     }
   },
+  onDragStart: {
+    description: 'Callback, вызываемый в начале перетаскивания узла. Возвращает информацию о событии и перетаскиваемом узле',
+    action: 'начало перетаскивания узла',
+    table: {
+      type: {
+        summary: '(e: TDragEvent[]) => void'
+      }
+    }
+  },
+  onDragEnd: {
+    description: 'Callback, вызываемый в конце перетаскивания узла. Возвращает информацию о событии и перетаскиваемом узле',
+    action: 'конец перетаскивания узла',
+    table: {
+      type: {
+        summary: '(e: TDragEvent[]) => void'
+      }
+    }
+  },
   checkable: {
     description: 'Включает отображение чекбоксов с каскадным выделением',
     table: {

--- a/src/components/TreeList/_stories/argsTypes.ts
+++ b/src/components/TreeList/_stories/argsTypes.ts
@@ -30,7 +30,7 @@ const argsTypes = {
     action: 'начало перетаскивания узла',
     table: {
       type: {
-        summary: '(e: TDragEvent[]) => void'
+        summary: '(e: TDragEvent) => void'
       }
     }
   },
@@ -39,7 +39,7 @@ const argsTypes = {
     action: 'конец перетаскивания узла',
     table: {
       type: {
-        summary: '(e: TDragEvent[]) => void'
+        summary: '(e: TDragEvent) => void'
       }
     }
   },

--- a/src/components/TreeList/example/TreeListExample.tsx
+++ b/src/components/TreeList/example/TreeListExample.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import React from 'react';
 
 import TreeList from '../TreeList';
-import { TNodeItem } from '../types';
+import { TDragEvent, TNodeItem } from '../types';
 import { DEFAULT_CHECKED_KEYS, DEFAULT_EXPANDED_KEYS, DEFAULT_TREE_DATA } from './constants';
 
 export const TreeListExample = (): JSX.Element => {
@@ -16,6 +16,16 @@ export const TreeListExample = (): JSX.Element => {
     setData(newData);
   };
 
+  const onDragStart = (e: TDragEvent) => {
+    // eslint-disable-next-line no-console
+    console.log('Drag start event: ',  e.event)
+  }
+
+  const onDragEnd = (e: TDragEvent) => {
+    // eslint-disable-next-line no-console
+    console.log('Drag end event; ', e.event)
+  }
+
   return (
     <TreeList
       data={data}
@@ -23,6 +33,8 @@ export const TreeListExample = (): JSX.Element => {
       checkable
       onSelectedNode={onSelectedNode}
       onDataAfterDrag={onDataAfterDrag}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       initialCheckedKeys={DEFAULT_CHECKED_KEYS}
       initialExpandedKeys={DEFAULT_EXPANDED_KEYS}
     />

--- a/src/components/TreeList/subcomponents/TreeListV1/index.tsx
+++ b/src/components/TreeList/subcomponents/TreeListV1/index.tsx
@@ -10,7 +10,7 @@ import 'rc-tree/assets/index.css';
 import styles from './TreeListV1.module.scss';
 
 import { ROW_PX_HEIGHTS, TITLE_VARIANT_BY_ROW_HEIGHT } from '../../constants';
-import { ERowHeight, TCheckedKeys, TDropEvent, TNodeItem, TTreeItem, TTreeListProps } from '../../types';
+import { ERowHeight, TCheckedKeys, TDragEvent, TDropEvent, TNodeItem, TTreeItem, TTreeListProps } from '../../types';
 import { addNodeAtKey, findAndRemoveNode, updateParentKeys } from './utils';
 
 export const TreeListV1 = ({
@@ -20,6 +20,8 @@ export const TreeListV1 = ({
   checkableSimple,
   onSelectedNode,
   onDataAfterDrag,
+  onDragStart,
+  onDragEnd,
   rowHeight = ERowHeight.s,
   initialCheckedKeys = [],
   initialExpandedKeys = []
@@ -54,6 +56,16 @@ export const TreeListV1 = ({
     setTreeData(data);
     if (onDataAfterDrag) onDataAfterDrag(data);
   };
+
+  const handleDragStart = (event: TDragEvent) => {
+    setDragging(String(event.node.key))
+    onDragStart && onDragStart(event)
+  }
+
+  const handleDragEnd = (event: TDragEvent) => {
+    setDragging(null)
+    onDragEnd && onDragEnd(event)
+  }
 
   const handleCheck = (_: TCheckedKeys, { checked, node }: { checked: boolean; node: TNodeItem }) => {
     const nodeKey = node?.key;
@@ -190,8 +202,8 @@ export const TreeListV1 = ({
         switcherIcon={() => null} // Отключаем стандартные стрелки
         checkable={false} // Отключение стандартных чекбоксов
         selectable={false} // Отключение возможности выбора узлов
-        onDragStart={info => setDragging(String(info.node.key))}
-        onDragEnd={() => setDragging(null)}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
         expandedKeys={expandedKeys}
       />
     </div>

--- a/src/components/TreeList/types.ts
+++ b/src/components/TreeList/types.ts
@@ -23,6 +23,8 @@ export type TNodeItem = TTreeItem<TСhildrenProps>;
 
 export type TCheckedKeys = Key[] | { checked: Key[]; halfChecked: Key[] };
 
+export type TDragEvent = NodeDragEventParams<DataNode>;
+
 export type TDropEvent = NodeDragEventParams<TNodeItem> & {
   dragNode: EventDataNode<TTreeItem>;
   dragNodesKeys: Key[];
@@ -46,6 +48,8 @@ export type TTreeListProps = {
   data: TNodeItem[];
   onSelectedNode?: (e: TSelectedNodeEvent) => void;
   onDataAfterDrag?: (e: TNodeItem[]) => void;
+  onDragStart?: (e: TDragEvent) => void;
+  onDragEnd?: (e: TDragEvent) => void;
   checkable?: boolean;
   draggable?: boolean;
   checkableSimple?: boolean;

--- a/src/components/_storybook/Introduction/Changelog.tsx
+++ b/src/components/_storybook/Introduction/Changelog.tsx
@@ -35,7 +35,7 @@ export const Changelog = () => {
               >
                 TreeList
               </Link>
-              <li className={styles['left-padding']}>- Добавлены пропсы onDragStart и onDragEnd</li>
+              <li className={styles['left-padding']}>- Добавлены свойства onDragStart и onDragEnd</li>
             </li>
           </ul>
         </div>

--- a/src/components/_storybook/Introduction/Changelog.tsx
+++ b/src/components/_storybook/Introduction/Changelog.tsx
@@ -23,6 +23,24 @@ export const Changelog = () => {
         </div>
         <div className={styles.history}>
           <Typography variant="Subheading3-Medium">
+            v2.22.4 - <span className={styles.date}>16.04.25</span>
+          </Typography>
+          <ul className={styles.list}>
+            <li>
+              • Изменен компонент{' '}
+              <Link
+                href="./?path=/docs/components-treelist-info--docs"
+                target="blank"
+                className={styles['link-changelog']}
+              >
+                TreeList
+              </Link>
+              <li className={styles['left-padding']}>- Добавлены пропсы onDragStart и onDragEnd</li>
+            </li>
+          </ul>
+        </div>
+        <div className={styles.history}>
+          <Typography variant="Subheading3-Medium">
             v2.22.3 - <span className={styles.date}>14.04.25</span>
           </Typography>
           <ul className={styles.list}>

--- a/src/components/_storybook/Stories/components/version.ts
+++ b/src/components/_storybook/Stories/components/version.ts
@@ -1,2 +1,2 @@
-const VERSION = '2.22.3';
+const VERSION = '2.22.4';
 export default VERSION;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { VideoWindowExample } from './components';
+import { TreeListExample } from './components/TreeList/example';
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
@@ -9,7 +9,7 @@ const root = createRoot(container!);
 root.render(
   <StrictMode>
     <div className="development-block">
-      <VideoWindowExample />
+      <TreeListExample />
     </div>
   </StrictMode>
 );


### PR DESCRIPTION
Добавлены пропсы:

```
onDragStart?: (e: TDragEvent) => void;
onDragEnd?: (e: TDragEvent) => void;
```

Добавлен тип на основе дженерика NodeDragEventParams<DataNode>:

```
type TDragEvent = {
  event: React.DragEvent<DataNode>;
  node: EventDataNode<DataNode>;
}
```

Обновлен Readme, обновлена основная история и argTypes, добавлен тест.