### PR TITLE
drawer-propagation-event | Click events fix

### DIFF
--- a/src/components/Drawer/_stories/Drawer.stories.tsx
+++ b/src/components/Drawer/_stories/Drawer.stories.tsx
@@ -1,6 +1,17 @@
 import React, { ReactNode, useState } from 'react';
+import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 
-import { Avatar, Box, Button, Divider, Drawer, IconEditPenOutlined24, Input, Typography } from '@components/index';
+import {
+  Avatar,
+  Box,
+  Button,
+  Drawer,
+  IconEditPenOutlined24,
+  IconEyeFilled24,
+  IconEyeOffOutlined24,
+  Input,
+  Typography
+} from '@components/index';
 import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 
@@ -13,6 +24,14 @@ const withWrapper = (Story: any) => {
   return <Story />;
 };
 
+interface Line {
+  key: string;
+  name: string;
+  canAdd: boolean;
+  visible: boolean;
+  units: string;
+}
+
 export default {
   title: 'Components/Drawer/Stories',
   component: Drawer,
@@ -20,8 +39,88 @@ export default {
   argTypes: argsTypes
 } as Meta<typeof Drawer>;
 
+// TODO: удалить после ревью
+function moveItem<T>(array: T[], index1: number, index2: number): T[] {
+  const newArray = [...array];
+  const [item] = newArray.splice(index1, 1);
+  newArray.splice(index2, 0, item);
+
+  return newArray;
+}
+
+interface ChartLine {
+  name: string;
+  color: string;
+  precision: number;
+  units: string;
+  max: number;
+  min: number;
+  description: string;
+  legendName?: string;
+  strokeDasharray?: string;
+}
+
+const LINES_CONFIG: Record<string, ChartLine> = {
+  specific_coke_wet: {
+    name: 'Уд. кокс. вл.',
+    color: 'var(--spectrum-green-50)',
+    precision: 1,
+    units: ' кг/т',
+    max: 400,
+    min: 250,
+    description: 'чистый расход кокса в подаче'
+  }
+};
+
 export const DrawerDefault = (args: IDrawerProps): ReactNode => {
   const [isOpen, setIsOpen] = useState(false);
+
+  // TODO: удалить после ревью
+  const search = '';
+  const [changedVisibleLines, setChangedVisibleLines] = useState(['specific_coke_wet']);
+  const [changedLinesOrder, setChangedLinesOrder] = useState([['specific_coke_wet']]);
+
+  const lines: Line[][] = changedLinesOrder.map(lines =>
+    lines.map(key => {
+      const line = LINES_CONFIG[key];
+      return {
+        key,
+        canAdd: true,
+        visible: changedVisibleLines.includes(key),
+        name: line.name + (line.units ? `, ${line.units}` : ''),
+        units: line.units
+      };
+    })
+  );
+
+  const filteredLines = lines.map(lines =>
+    lines.filter(line => line.name.toLowerCase().includes(search.toLowerCase()))
+  );
+
+  const toggleVisible = (line: Line) => {
+    if (changedVisibleLines.includes(line.key)) {
+      setChangedVisibleLines(changedVisibleLines.filter(l => l !== line.key));
+    } else if (line.canAdd) {
+      setChangedVisibleLines([...changedVisibleLines, line.key]);
+    } else {
+      const linesByUnits = lines.find(l => l[0].units === line.units)?.map(l => l.key);
+      setChangedVisibleLines(linesByUnits ?? []);
+    }
+  };
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      return;
+    }
+
+    const index = Number(result.destination.droppableId);
+
+    const groupedKeyLines = filteredLines.map(lines => lines.map(line => line.key));
+
+    groupedKeyLines[index] = moveItem(groupedKeyLines[index], result.source.index, result.destination.index);
+
+    setChangedLinesOrder(groupedKeyLines);
+  };
 
   return (
     <div>
@@ -48,6 +147,60 @@ export const DrawerDefault = (args: IDrawerProps): ReactNode => {
             </Button>
           </Box>
         </Box>
+
+        {/* TODO: удалить после ревью */}
+        <div>
+          {filteredLines.map((lines, linesIndex) => (
+            <DragDropContext onDragEnd={onDragEnd} key={linesIndex}>
+              <Droppable droppableId={String(linesIndex)}>
+                {provided => (
+                  <div {...provided.droppableProps} ref={provided.innerRef}>
+                    {lines.map((line, index) => (
+                      <Draggable key={line.key} draggableId={line.key} index={index}>
+                        {provided => (
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            style={provided.draggableProps.style}
+                            key={line.key}
+                          >
+                            <div key={line.key}>
+                              <Button
+                                color="ghost"
+                                variant="secondary"
+                                iconButton={
+                                  line.visible ? (
+                                    <IconEyeFilled24 color="primary" />
+                                  ) : (
+                                    <IconEyeOffOutlined24 color={line.canAdd ? 'primary' : 'action'} />
+                                  )
+                                }
+                                onClick={() => {
+                                  toggleVisible(line);
+                                }}
+                              ></Button>
+                              <Button
+                                color="ghost"
+                                variant="secondary"
+                                onClick={() => {
+                                  toggleVisible(line);
+                                }}
+                              >
+                                hello
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+          ))}
+        </div>
       </Drawer>
     </div>
   );

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { FC, ReactElement, useEffect, useRef, useState } from 'react';
 
 import { EButtonSize } from '@components/Button/enums';
 import { EClickAwayEvent } from '@components/ClickAwayListener/types';
@@ -112,6 +112,7 @@ const Drawer: FC<IDrawerProps> = ({
       data-testid="DRAWER"
     >
       <ClickAwayListener
+        excludeRef={[drawerRef]}
         eventType={clickAwayEventType}
         className={clsx(styles.wrapper, styles[position], {
           [styles.slideOutLeft]: isClosing && position === EDrawerPosition.left,
@@ -127,7 +128,16 @@ const Drawer: FC<IDrawerProps> = ({
           style={isHorizontal ? { width } : { height }}
         >
           <div className={clsx(styles.drawerContent, styles[position])} data-ui-drawer-content>
-            {children}
+            {React.Children.map(children, child => {
+              return React.cloneElement(child as ReactElement, {
+                onClick: (e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  if (React.isValidElement(child) && child.props.onClick) {
+                    child.props.onClick(e);
+                  }
+                }
+              });
+            })}
           </div>
         </div>
         {!isClosing && isViewCloseButton && (


### PR DESCRIPTION
В компоненте Drawer некоторые события клика в children срабатывают на событие закрытия Drawer

Пример взят из МЕС-ДП, после ревью сторю можно откатить до стори по умолчанию