### PR TITLE
grid-bootstrap-props | Grid MUI props

### DIFF
--- a/src/components/Grid/Grid.module.scss
+++ b/src/components/Grid/Grid.module.scss
@@ -1,0 +1,53 @@
+.grid {
+  display: block;
+
+  &.container {
+    display: flex;
+    flex-wrap: wrap;
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  @for $i from 1 through 12 {
+    &.xs-#{$i} {
+      flex-grow: $i;
+      max-width: calc((100% / 12 * $i)); 
+    }
+  }
+
+  @media (min-width: 600px) {
+    @for $i from 1 through 12 {
+      &.sm-#{$i} {
+        flex-grow: $i;
+        max-width: calc(100% / 12 * $i);
+      }
+    }
+  }
+
+  @media (min-width: 960px) {
+    @for $i from 1 through 12 {
+      &.md-#{$i} {
+        flex-grow: $i;
+        max-width: calc(100% / 12 * $i);
+      }
+    }
+  }
+
+  @media (min-width: 1280px) {
+    @for $i from 1 through 12 {
+      &.lg-#{$i} {
+        flex-grow: $i;
+        max-width: calc(100% / 12 * $i);
+      }
+    }
+  }
+
+  @media (min-width: 1920px) {
+    @for $i from 1 through 12 {
+      &.xl-#{$i} {
+        flex-grow: $i;
+        max-width: calc(100% / 12 * $i);
+      }
+    }
+  }
+}

--- a/src/components/Grid/_stories/Grid.stories.tsx
+++ b/src/components/Grid/_stories/Grid.stories.tsx
@@ -10,7 +10,7 @@ import { argsTypes } from './argsTypes';
 
 const withPadding = (Story: () => any) => (
   <div className={styles.wrapper} style={{ minHeight: 80 }}>
-    {<Story/>}
+    {<Story />}
   </div>
 );
 
@@ -730,3 +730,24 @@ ColumnBreaks.storyName = 'Разрывы колонок';
 ColumnBreaks.args = {
   background: 'var(--text-grey-200)'
 };
+
+export const GridWithSizeProp = (argTypes: IBox): JSX.Element => {
+  return (
+    <Grid container gap={8} {...argTypes}>
+      <Grid size={{ xs: 6, md: 8 }} borderRadius="var(--4-border)" background="var(--primary-blue-400)">
+        <div>xs=6 md=8</div>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }} borderRadius="var(--4-border)" background="var(--primary-blue-400)">
+        <div>xs=6 md=4</div>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }} borderRadius="var(--4-border)" background="var(--primary-blue-400)">
+        <div>xs=6 md=4</div>
+      </Grid>
+      <Grid size={{ xs: 6, md: 8 }} borderRadius="var(--4-border)" background="var(--primary-blue-400)">
+        <div>xs=6 md=8</div>
+      </Grid>
+    </Grid>
+  );
+};
+
+GridWithSizeProp.storyName = 'Grid c использованием bootstrap параметра size';

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -1,12 +1,37 @@
 import React from 'react';
 
 import Box from '@components/Box';
-import { IGrid } from '@components/Grid/types';
+import { IGrid, IGridSize } from '@components/Grid/types';
+
+import styles from './Grid.module.scss';
 
 import { GridColumn, GridRow } from './subcomponents';
 
-const Grid = ({ children, ...props }: IGrid) => {
-  return <Box {...props}>{children}</Box>;
+const Grid = ({ children, container, size, gap = 0, ...props }: IGrid) => {
+  const classNames = [styles.grid];
+
+  if (container) {
+    classNames.push(styles.container);
+  }
+
+  const sizes = typeof size === 'number' ? { xs: size } : size || {};
+
+  Object.keys(sizes).forEach(breakpoint => {
+    const value = sizes[breakpoint as keyof IGridSize];
+    if (value) {
+      classNames.push(`${styles[`${breakpoint}-${value}`]}`);
+    }
+  });
+
+  return (
+    <Box  
+      className={classNames.join(' ')}
+      gap={gap}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
 };
 
 Grid.Column = GridColumn;

--- a/src/components/Grid/types.ts
+++ b/src/components/Grid/types.ts
@@ -1,16 +1,15 @@
 import { IBox } from '@components/Box/types';
 
-export type IGrid = IBox
+export type TGridSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-/**
- * В дальнейшем можно/нужно добавить пропсы для адаптива
- * к примеру как в bootstrap
- * export interface IGrid extends IBox {
- *   xs?: number;
- *   sm?: number;
- *   md?: number;
- *   lg?: number;
- *   xl?: number;
- * }
- */
-
+export interface IGridSize {
+  xs?: TGridSize;
+  sm?: TGridSize;
+  md?: TGridSize;
+  lg?: TGridSize;
+  xl?: TGridSize;
+}
+export interface IGrid extends IBox {
+  container?: boolean;
+  size?: TGridSize | IGridSize;
+}


### PR DESCRIPTION
Добавлены пропсы container и size, пример: 

size={{ xs: 6, md: 4 }} или size={6}

Проп size соответствует грид-системе в Bootstrap.

Сейчас это драфт-ПР, тк остался баг с растягиванием элементов по нескольким строкам