### PR TITLE
datepicker-portal-bugfix | DatePicker withPortal fix

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { usePopper } from 'react-popper';
 
@@ -107,7 +107,8 @@ export const DatePicker: TDatePickerProps = ({
   const withShift = useMemo(() => type === 'shift', [type]);
   const [isOpen, setOpen] = useState(false);
   const [inputRef, setInputRef] = useState<null | HTMLInputElement>(null);
-  const [calendarRef, setCalendarRef] = useState<null | HTMLDivElement>(null);
+  const [calendarElement, setCalendarElement] = useState<null | HTMLDivElement>(null);
+  const calendarRef = useRef<null | HTMLDivElement>(null)
   const [toggle, setToggle] = useState(false);
 
   id = useMemo(() => `DatePicker-${id?.toString() ?? performance.now().toString().split('.').join('')}`, [id]);
@@ -187,7 +188,13 @@ export const DatePicker: TDatePickerProps = ({
     }
   }, [handleClose, pseudo]);
 
-  const { styles: popperStyles, attributes } = usePopper(inputRef, calendarRef, {
+  useEffect(() => {
+    if (calendarElement) {
+      calendarRef.current = calendarElement;
+    }
+  }, [calendarElement])
+
+  const { styles: popperStyles, attributes } = usePopper(inputRef, calendarElement, {
     placement: 'bottom-start'
   });
 
@@ -226,7 +233,7 @@ export const DatePicker: TDatePickerProps = ({
     <CalendarPanel
       type={type}
       level={level}
-      ref={setCalendarRef}
+      ref={setCalendarElement}
       withPeriod={withPeriod}
       valueFrom={valueFrom}
       valueTo={valueTo}
@@ -331,7 +338,7 @@ export const DatePicker: TDatePickerProps = ({
       {pseudo ? (
         <PseudoInput label={withTime ? 'Дата и время' : 'Дата'}>{pseudoChildren}</PseudoInput>
       ) : (
-        (isOpenOnFocus && <ClickAwayListener onClickAway={handleClose}>{renderDatepicker()}</ClickAwayListener>) || (
+        (isOpenOnFocus && <ClickAwayListener excludeRef={calendarRef} onClickAway={handleClose}>{renderDatepicker()}</ClickAwayListener>) || (
           <>{renderDatepicker()}</>
         )
       )}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
-import React, { StrictMode } from 'react';
+import React, { StrictMode, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { OptionItem, SimpleSelect, Typography } from './components';
+import { DatePicker, OptionItem, SimpleSelect, Typography } from './components';
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
@@ -16,16 +16,33 @@ const options = [
   { value: 'tin', label: 'Tin' }
 ];
 
+const Component = () => {
+  const [value, onChange] = useState(new Date());
+  return (
+    <div style={{ height: '330px' }}>
+      <DatePicker
+        value={value}
+        onChange={onChange}
+        withPortal
+        portalContainerId="portal-container"
+        isOpenOnFocus
+      />
+      <div id="portal-container">Тут появится CalendarPanel</div>
+    </div>
+  );
+};
+
 root.render(
   <StrictMode>
     <div className="development-block" style={{ height: 200 }}>
-      <SimpleSelect value={'steel'}>
+      {/* <SimpleSelect value={'steel'}>
         {options.map(({ value, label, disabled }) => (
           <OptionItem key={value} value={value} label={label} disabled={disabled}>
             <Typography variant="Body1-Medium">{label}</Typography>
           </OptionItem>
         ))}
-      </SimpleSelect>
+      </SimpleSelect> */}
+      <Component />
     </div>
   </StrictMode>
 );


### PR DESCRIPTION
Пропсы withPortal и isOpenOnFocus отрабатывал неверно: calendarPanel воспринимался вне ClickAwayListener и из-за этого закрывался прежде чем пользователь выберет значение из календаря. Сейчас компонент отрабатывает верно, см. пример в src/index.tsx

https://github.com/user-attachments/assets/e8604c75-30cd-4696-99e3-07f1e70f6a17

