### PR TITLE
fix: add ComboList disabled styles and ComboDraggableList disabled state

### DIFF
--- a/src/components/ComboBox/_stories/ComboBox.stories.tsx
+++ b/src/components/ComboBox/_stories/ComboBox.stories.tsx
@@ -28,7 +28,7 @@ const simpleOptions: IComboBoxOption[] = [
   { id: '2', label: 'Сталь легированная' },
   { id: '3', label: 'Чугун серый' },
   { id: '4', label: 'Чугун ковкий' },
-  { id: '5', label: 'Алюминиевые сплавы' },
+  { id: '5', label: 'Алюминиевые сплавы', disabled: true },
   { id: '6', label: 'Медные сплавы' }
 ];
 

--- a/src/components/ComboBox/subcomponents/ComboDraggableList/ComboDraggableList.module.scss
+++ b/src/components/ComboBox/subcomponents/ComboDraggableList/ComboDraggableList.module.scss
@@ -25,6 +25,11 @@
       align-items: center;
     }
 
+    &--disabled {
+      background-color: var(--steel-10);
+      opacity: 0.5;
+    }
+
     &--active {
       background-color: var(--brand-sapphire-10);
 
@@ -52,7 +57,7 @@
 
     &__checkbox {
       flex: 1;
-      
+
       & > label {
         padding: 0 0 0 4px;
         text-wrap: nowrap;
@@ -74,7 +79,7 @@
   color: var(--steel-70);
   flex-shrink: 0;
   cursor: grab;
-  
+
   &:active {
     cursor: grabbing;
   }

--- a/src/components/ComboBox/subcomponents/ComboDraggableList/index.tsx
+++ b/src/components/ComboBox/subcomponents/ComboDraggableList/index.tsx
@@ -110,7 +110,8 @@ const ComboDraggableList = <T extends IComboBoxOption>({
             ref={provided.innerRef}
             className={clsx(styles['list-item'], styles['list-item--draggable'], {
               [styles['list-item--active']]: isChecked,
-              [styles['list-item--dragging']]: snapshot.isDragging
+              [styles['list-item--dragging']]: snapshot.isDragging,
+              [styles['list-item--disabled']]: Boolean(item.disabled)
             })}
             {...provided.draggableProps}
             style={provided.draggableProps.style}
@@ -121,6 +122,7 @@ const ComboDraggableList = <T extends IComboBoxOption>({
             {isMultiple && (
               <Checkbox
                 checked={isChecked}
+                disabled={Boolean(item.disabled)}
                 label={item.label}
                 onChange={() => handleMultiChange(item)}
                 className={styles['list-item__checkbox']}
@@ -130,7 +132,7 @@ const ComboDraggableList = <T extends IComboBoxOption>({
               <Typography
                 variant="Body1-Medium"
                 className={styles['list-item__label']}
-                onClick={() => handleChange(item)}
+                onClick={() => !item.disabled && handleChange(item)}
               >
                 {item.label}
               </Typography>

--- a/src/components/ComboBox/subcomponents/ComboList/ComboList.module.scss
+++ b/src/components/ComboBox/subcomponents/ComboList/ComboList.module.scss
@@ -26,6 +26,11 @@
   }
 }
 
+.listItemDisabled {
+  background-color: var(--steel-10);
+  opacity: 0.5;
+}
+
 .listItemLabel {
   line-height: 24px;
   margin: 0;


### PR DESCRIPTION
В компонентах СomboList и ComboDraggableList не работает disabled state для опций 

Changelog
1.  listItemDisabled класс был правильно присвоен в ComboList,  но  его не было в файле со стилями, добавил
2. ComboDraggableList не содержал логики disable опций, добавил
3. Добавил disabled: true у опции в storybook чтобы отражать возможность disable у опции